### PR TITLE
Fix-worker-queue

### DIFF
--- a/src/nxrefine/nxrefine.py
+++ b/src/nxrefine/nxrefine.py
@@ -556,7 +556,7 @@ class NXRefine:
                         'transmission' in self.entry['instrument/sample']):
                     if 'transmission' in other.entry['instrument/sample']:
                         del other.entry['instrument/sample/transmission']
-                    other['instrument/sample/transmission'] = (
+                    other.entry['instrument/sample/transmission'] = (
                         self.entry['instrument/sample/transmission'])
 
     def link_sample(self, other):

--- a/src/nxrefine/nxserver.py
+++ b/src/nxrefine/nxserver.py
@@ -111,7 +111,7 @@ class NXTask:
 
     def __init__(self, command, server):
         self.command = command
-        self.name = command
+        self.name = command.split()[0]
         self.server = server
 
     def __repr__(self):

--- a/src/nxrefine/nxserver.py
+++ b/src/nxrefine/nxserver.py
@@ -139,7 +139,7 @@ class NXTask:
             command = f"pdsh -w {cpu} {command}"
         elif self.server.run_command == 'qsub':
             command = (f"qsub -q all.q -j y -o {log_file} "
-                       f"-N {command.split()[0]} -S /bin/bash {command}")
+                       f"-N {self.command.split()[0]} -S /bin/bash {command}")
         return command
 
     def execute(self, cpu, log_file):


### PR DESCRIPTION
* Fixes an issue with synchronizing file queues between processes.
* Uses the Python Queue `maxsize` parameter to limit worker jobs.
* Fixes an issue with qsub job names.
* Fixes a problem with copying transmissions between entries. 