### PR TITLE
Fix-database-paths

### DIFF
--- a/src/nxrefine/nxdatabase.py
+++ b/src/nxrefine/nxdatabase.py
@@ -217,12 +217,13 @@ class NXDatabase:
             Updated File object.
         """
         f = self.get_file(filename)
+        filepath = self.get_filepath(filename)
         if f:
             try:
                 scan_files = self.get_directory(filename).iterdir()
             except OSError:
                 scan_files = []
-            root = nxload(filename)
+            root = nxload(filepath)
             entries = [e for e in root.entries if e != 'entry']
             tasks = {t: 0 for t in self.task_names}
             for e in entries:

--- a/src/nxrefine/nxserver.py
+++ b/src/nxrefine/nxserver.py
@@ -67,11 +67,16 @@ class NXFileQueue(FileQueue):
 
     def fix_access(self):
         """Ensure that the file queue pointer is readable."""
-        try:
-            for f in [f for f in self.directory.iterdir() if f.is_file()]:
-                self.directory.joinpath(f).chmod(0o664)
-        except Exception:
-            pass
+        for f in [f for f in self.directory.iterdir() if f.is_file()]:
+            try:
+                self.directory.joinpath(f).chmod(0o666)
+            except Exception:
+                pass
+        for f in [f for f in self.directory.iterdir() if f.is_dir()]:
+            try:
+                self.directory.joinpath(f).chmod(0o777)
+            except Exception:
+                pass
 
 
 class NXWorker(Thread):


### PR DESCRIPTION
* Fixes the file path used in the NXDatabase `sync_file` function.
* Ensures that all NXFileQueue permissions are updated after each queue operation.