### PR TITLE
Fix punches when they overlap Brillouin Zones.

### DIFF
--- a/src/nxrefine/nxreduce.py
+++ b/src/nxrefine/nxreduce.py
@@ -2236,7 +2236,7 @@ class NXMultiReduce(NXReduce):
                 v = symm_data[(lslice, kslice, hslice)].nxvalue
                 if v.max() > 0.0:
                     w = LaplaceInterpolation.matern_3d_grid(v, idx)
-                    fill_data[(lslice, kslice, hslice)] = w * mask
+                    fill_data[(lslice, kslice, hslice)] += np.where(mask, w, 0)
             except Exception:
                 pass
 


### PR DESCRIPTION
* Fixes punches when the hole radius is larger than the Brillouin Zone along one axis.