### PR TITLE
Remove call to deprecated NumPy float function

### DIFF
--- a/src/nxrefine/plugins/refine/calibrate_powder.py
+++ b/src/nxrefine/plugins/refine/calibrate_powder.py
@@ -226,7 +226,7 @@ class CalibrateDialog(NXDialog):
             r = distance * np.tan(theta) / self.pixel_size
             phi = self.phi_max = -np.pi
             while phi < np.pi:
-                x, y = np.int(xc + r*np.cos(phi)), np.int(yc + r*np.sin(phi))
+                x, y = int(xc + r*np.cos(phi)), int(yc + r*np.sin(phi))
                 if ((x > 0 and x < self.data.x.max()) and
                     (y > 0 and y < self.data.y.max()) and
                         not self.pixel_mask[y, x]):

--- a/src/nxrefine/plugins/refine/find_maximum.py
+++ b/src/nxrefine/plugins/refine/find_maximum.py
@@ -154,7 +154,7 @@ class MaximumDialog(NXDialog):
 
     @property
     def maximum(self):
-        return np.float(self.output.text().split()[-1])
+        return float(self.output.text().split()[-1])
 
     @maximum.setter
     def maximum(self, value):


### PR DESCRIPTION
* Replaces call to `np.float` and `np.int` with recommended `float` and `int`, respectively.