### PR TITLE
Make-root-readonly

### DIFF
--- a/src/nxrefine/nxbeamline.py
+++ b/src/nxrefine/nxbeamline.py
@@ -171,7 +171,7 @@ class Sector6Beamline(NXBeamLine):
         for i, key in enumerate(meta_input.dtype.names):
             logs[key] = [array[i] for array in meta_input]
 
-        with self.root.nxfile:
+        with self.reduce:
             if 'instrument' not in self.entry:
                 self.entry['instrument'] = NXinstrument()
             if 'logs' in self.entry['instrument']:
@@ -414,7 +414,7 @@ class QM2Beamline(NXBeamLine):
             self.reduce.logger.info(f"'{spec_file}' does not exist")
             raise NeXusError('SPEC file not found')
 
-        with self.root.nxfile:
+        with self.reduce:
             scan_number = self.entry['scan_number'].nxvalue
             logs = SpecParser(spec_file).read(scan_number).NXentry[0]
             logs.nxclass = NXsubentry

--- a/src/nxrefine/nxbeamline.py
+++ b/src/nxrefine/nxbeamline.py
@@ -279,14 +279,21 @@ class QM2Beamline(NXBeamLine):
                 continue
             scan_directory = self.base_directory / scan.name
             scan_directory.mkdir(exist_ok=True)
-            with nxopen(scan_file, 'w') as root:
-                root['entry'] = self.config_file['entry']
+            if overwrite:
+                mode = 'w'
+            else:
+                mode = 'a'
+            with nxopen(scan_file, mode) as root:
+                if 'entry' not in root:
+                    root['entry'] = self.config_file['entry']
                 i = 0
                 for s in scan_directories:
                     scan_number = self.get_index(s, directory=True)
                     if scan_number:
                         i += 1
                         entry_name = f"f{i}"
+                        if entry_name in root and not overwrite:
+                            continue
                         root[entry_name] = self.config_file['f1']
                         entry = root[entry_name]
                         entry['scan_number'] = scan_number

--- a/src/nxrefine/nxdatabase.py
+++ b/src/nxrefine/nxdatabase.py
@@ -195,7 +195,7 @@ class NXDatabase:
             if (f.entries is None or f.entries == ''
                     or isinstance(f.entries, int)):
                 root = nxload(filepath)
-                f.set_entries([e for e in root.entries if e != 'entry'])
+                f.set_entries([e for e in root.entries if e[-1].isdigit()])
             f = self.sync_data(filename)
         return f
 

--- a/src/nxrefine/nxreduce.py
+++ b/src/nxrefine/nxreduce.py
@@ -255,6 +255,14 @@ class NXReduce(QtCore.QObject):
     def __repr__(self):
         return f"NXReduce('{self.name}')"
 
+    def __enter__(self):
+        self.root.unlock()
+        return self.root.__enter__()
+
+    def __exit__(self, *args):
+        self.root.__exit__()
+        self.root.lock()
+
     @property
     def task_directory(self):
         """Directory containing log files and the reduction database."""
@@ -552,8 +560,7 @@ class NXReduce(QtCore.QObject):
         local copy in the current wrapper file's '/entry/nxreduce'
         group.
         """
-        self.root.unlock()
-        with self.root.nxfile:
+        with self:
             if 'nxreduce' not in self.root['entry']:
                 self.root['entry/nxreduce'] = NXparameters()
             if threshold is not None:
@@ -586,7 +593,6 @@ class NXReduce(QtCore.QObject):
             if radius is not None:
                 self.radius = radius
                 self.root['entry/nxreduce/radius'] = self.radius
-        self.root.lock()
 
     def clear_parameters(self, parameters):
         """Remove legacy records of parameters in the 'peaks' group."""
@@ -867,8 +873,7 @@ class NXReduce(QtCore.QObject):
         note = NXnote(process, (f"Current machine: {platform.node()}\n" +
                                 f"Current directory: {self.directory}\n" +
                                 parameters))
-        self.root.unlock()
-        with self.root.nxfile:
+        with self:
             if process in self.entry:
                 del self.entry[process]
             self.entry[process] = NXprocess(
@@ -877,7 +882,6 @@ class NXReduce(QtCore.QObject):
                 version='nxrefine v' + __version__, note=note)
             for key in [k for k in kwargs if k in self.default]:
                 self.entry[process][key] = kwargs[key]
-        self.root.lock()
 
     def record_start(self, task):
         """ Record that a task has started in the database """
@@ -961,8 +965,7 @@ class NXReduce(QtCore.QObject):
 
     def link_data(self):
         if self.field:
-            self.root.unlock()
-            with self.root.nxfile:
+            with self:
                 frames = np.arange(self.shape[0], dtype=np.int32)
                 if 'instrument/detector/frame_time' in self.entry:
                     frame_time = self.entry['instrument/detector/frame_time']
@@ -996,7 +999,6 @@ class NXReduce(QtCore.QObject):
                 self.entry['data'].nxaxes = [self.entry['data/frame_number'],
                                              self.entry['data/y_pixel'],
                                              self.entry['data/x_pixel']]
-            self.root.lock()
         else:
             self.logger.info("No raw data loaded")
 
@@ -1128,8 +1130,7 @@ class NXReduce(QtCore.QObject):
         return result
 
     def write_maximum(self):
-        self.root.unlock()
-        with self.root.nxfile:
+        with self:
             self.entry['data'].attrs['maximum'] = self.maximum
             self.entry['data'].attrs['first'] = self.first
             self.entry['data'].attrs['last'] = self.last
@@ -1144,7 +1145,6 @@ class NXReduce(QtCore.QObject):
                                                  self.entry['data'].nxaxes[0])
             self.entry['summed_frames/partial_frames'] = self.partial_frames
             self.calculate_radial_sums()
-        self.root.lock()
         self.clear_parameters(['first', 'last'])
 
     def calculate_radial_sums(self):
@@ -1171,8 +1171,7 @@ class NXReduce(QtCore.QObject):
                 correctSolidAngle=True, method=('no', 'histogram', 'cython'))
             Q = (4 * np.pi * np.sin(np.radians(polar_angle) / 2.0)
                  / (ai.wavelength * 1e10))
-            self.root.unlock()
-            with self.root.nxfile:
+            with self:
                 if 'radial_sum' in self.entry:
                     del self.entry['radial_sum']
                 self.entry['radial_sum'] = NXdata(
@@ -1182,11 +1181,9 @@ class NXReduce(QtCore.QObject):
                 if 'polarization' in self.entry['instrument/detector']:
                     del self.entry['instrument/detector/polarization']
                 self.entry['instrument/detector/polarization'] = polarization
-            self.root.lock()
         except Exception as error:
             self.logger.info("Unable to create radial sum")
             self.logger.info(str(error))
-            self.root.lock()
             return None
 
     def sample_transmission(self):
@@ -1357,8 +1354,7 @@ class NXReduce(QtCore.QObject):
         group.attrs['first'] = self.first
         group.attrs['last'] = self.last
         group.attrs['threshold'] = self.threshold
-        self.root.unlock()
-        with self.root.nxfile:
+        with self:
             if 'peaks' in self.entry:
                 del self.entry['peaks']
             self.entry['peaks'] = group
@@ -1366,7 +1362,6 @@ class NXReduce(QtCore.QObject):
             polar_angles, azimuthal_angles = refine.calculate_angles(refine.xp,
                                                                      refine.yp)
             refine.write_angles(polar_angles, azimuthal_angles)
-        self.root.lock()
         self.clear_parameters(['threshold', 'first', 'last'])
 
     def nxrefine(self):
@@ -1420,10 +1415,8 @@ class NXReduce(QtCore.QObject):
             return None
 
     def write_refinement(self, refine):
-        self.root.unlock()
-        with self.root.nxfile:
+        with self:
             refine.write_parameters()
-        self.root.lock()
 
     def nxprepare(self):
         if self.not_processed('nxprepare_mask') and self.prepare:
@@ -1609,8 +1602,7 @@ class NXReduce(QtCore.QObject):
                 self.Qh = self.Qk = self.Ql = None
 
     def get_normalization(self):
-        self.root.unlock()
-        with self.root.nxfile:
+        with self:
             if self.norm and self.monitor in self.entry:
                 self.data['monitor_weight'] = self.read_monitor()
                 inst = self.entry['instrument']
@@ -1634,7 +1626,6 @@ class NXReduce(QtCore.QObject):
             self.data['monitor_weight'][:self.first] = 0.0
             self.data['monitor_weight'][self.last+1:] = 0.0
             self.data['monitor_weight'].attrs['axes'] = 'frame_number'
-        self.root.lock()
 
     def prepare_transform(self, mask=False):
         settings_file = os.path.join(self.directory,
@@ -1649,10 +1640,8 @@ class NXReduce(QtCore.QObject):
             refine.k_start, refine.k_step, refine.k_stop = self.Qk
             refine.l_start, refine.l_step, refine.l_stop = self.Ql
             refine.define_grid()
-            self.root.unlock()
-            with self.root.nxfile:
+            with self:
                 refine.prepare_transform(self.transform_file, mask=mask)
-            self.root.lock()
             refine.write_settings(settings_file)
             command = refine.cctw_command(mask)
             if command and os.path.exists(self.transform_file):
@@ -1752,12 +1741,10 @@ class NXReduce(QtCore.QObject):
                 if 'monitor_weight' not in reduce.entry['data']:
                     reduce.get_normalization()
                 monitor_weight += reduce.entry['data/monitor_weight'].nxvalue
-        self.root.unlock()
-        with self.root.nxfile:
+        with self:
             self.entry['monitor1/MCS1'] = monitor1
             self.entry['monitor2/MCS2'] = monitor2
             self.entry['data/monitor_weight'] = monitor_weight
-        self.root.lock()
 
     def nxreduce(self):
         if self.load:
@@ -1998,8 +1985,7 @@ class NXMultiReduce(NXReduce):
 
     def prepare_combine(self):
         try:
-            self.root.unlock()
-            with self.root.nxfile:
+            with self:
                 entry = self.entries[0]
                 Qh, Qk, Ql = (self.root[entry][self.transform_path]['Qh'],
                               self.root[entry][self.transform_path]['Qk'],
@@ -2021,11 +2007,9 @@ class NXMultiReduce(NXReduce):
                     self.refine.alpha_star)
                 self.add_title(self.entry[self.transform_path])
                 self.entry[self.transform_path].set_default(over=True)
-            self.root.lock()
         except Exception as error:
             self.logger.info("Unable to initialize transform group")
             self.logger.info(str(error))
-            self.root.lock()
             return None
         input = ' '.join([os.path.join(
             self.directory,
@@ -2406,8 +2390,7 @@ class NXMultiReduce(NXReduce):
         shutil.copyfile(os.path.join(self.base_directory,
                                      self.sample+'_'+scan_list[0]+'.nxs'),
                         self.wrapper_file)
-        self.root.unlock()
-        with self.root.nxfile:
+        with self:
             if 'nxcombine' in self.root['entry']:
                 del self.root['entry/nxcombine']
             if 'nxmasked_combine' in self.root['entry']:
@@ -2430,7 +2413,6 @@ class NXMultiReduce(NXReduce):
                     del entry['nxtransform']
                 if 'nxmasked_transform' in entry:
                     del entry['nxmasked_transform']
-        self.root.lock()
         self.db.update_file(self.wrapper_file)
 
     def nxreduce(self):

--- a/src/nxrefine/nxreduce.py
+++ b/src/nxrefine/nxreduce.py
@@ -356,7 +356,16 @@ class NXReduce(QtCore.QObject):
         if self._entries:
             return self._entries
         else:
-            return [entry for entry in self.root.entries if entry != 'entry']
+            entries = [entry for entry in self.root.entries
+                       if entry[-1].isdigit()]
+            try:
+                f = self.db.get_file(self.wrapper_file)
+                if len(f.get_entries()) != len(entries):
+                    f.set_entries(entries)
+                    self.db.session.commit()
+            except Exception:
+                pass
+            return entries
 
     @property
     def first_entry(self):

--- a/src/nxrefine/nxrefine.py
+++ b/src/nxrefine/nxrefine.py
@@ -340,15 +340,16 @@ class NXRefine:
                 'instrument/goniometer/chi', self.chi)
             self.omega = self.read_parameter('instrument/goniometer/omega',
                                              self.omega)
-            if 'theta' in self.entry['instrument/goniometer']:
-                self.theta = self.read_parameter('instrument/goniometer/theta',
-                                                 self.theta)
-            elif 'goniometer_pitch' in self.entry['instrument/goniometer']:
-                self.theta = self.read_parameter(
-                    'instrument/goniometer/goniometer_pitch', self.theta)
-            elif 'gonpitch' in self.entry['instrument/goniometer']:
-                self.theta = self.read_parameter(
-                    'instrument/goniometer/gonpitch', self.theta)
+            if 'instrument/goniometer' in self.entry:
+                if 'theta' in self.entry['instrument/goniometer']:
+                    self.theta = self.read_parameter(
+                        'instrument/goniometer/theta', self.theta)
+                elif 'goniometer_pitch' in self.entry['instrument/goniometer']:
+                    self.theta = self.read_parameter(
+                        'instrument/goniometer/goniometer_pitch', self.theta)
+                elif 'gonpitch' in self.entry['instrument/goniometer']:
+                    self.theta = self.read_parameter(
+                        'instrument/goniometer/gonpitch', self.theta)
             self.symmetry = self.read_parameter('sample/unit_cell_group',
                                                 self.symmetry)
             self.centring = self.read_parameter('sample/lattice_centring',


### PR DESCRIPTION
* Makes the NXReduce root object read-only by default.
* Defines a context manager for NXReduce instances that is used to unlock and lock the root objects for writing.
* Allows the number of entries to be updated in the database.